### PR TITLE
Can no longer use put in certain sagas

### DIFF
--- a/src/SagaRepository.js
+++ b/src/SagaRepository.js
@@ -29,10 +29,7 @@ export default class SagaRepository {
     dispatch
   ) {
     if (!this.sagas[sagaId]) {
-      const sagaInstance = new SagaAbstraction(saga, model);
-      sagaInstance.subscribe(dispatch);
-
-      this.sagas[sagaId] = sagaInstance;
+      this.sagas[sagaId] = new SagaAbstraction(saga, model, dispatch);
     } else {
       warn(
         'The Saga instance has already been mounted, this basically mean ' +

--- a/src/sagas/ReduxSaga.js
+++ b/src/sagas/ReduxSaga.js
@@ -13,13 +13,14 @@ export default class ReduxSaga {
    *
    * @param {Generator} Saga implementation
    * @param {any} initial model
+   * @param {Function} dispatch function
    */
-  constructor(saga, model) {
+  constructor(saga, model, dispatch) {
     this.updateModel(model);
 
     this.dispatchSubject = new Subject();
     this.subscribeSubject = new Subject();
-    this.subscription = null;
+    this.subscription = this.subscribeSubject.subscribe(dispatch);
 
     this.saga = runSaga(saga(), {
       subscribe: cb => {
@@ -46,22 +47,6 @@ export default class ReduxSaga {
    */
   updateModel(model) {
     this.model = model;
-  }
-
-  /**
-   * Subscribes to all the actions
-   * newly created by Saga implementation. It's
-   * the output of the action pipe.
-   *
-   * @param {Function} Subscriber function
-   * @return {Disposable} RXJS Disposable
-   */
-  subscribe(subscriber) {
-    this.subscription = this
-      .subscribeSubject
-      .subscribe(subscriber);
-
-    return this.subscription;
   }
 
   /**

--- a/src/sagas/RxjsSaga.js
+++ b/src/sagas/RxjsSaga.js
@@ -14,13 +14,16 @@ export default class RxjsSaga {
    *
    * @param {Function} Saga implementation
    * @param {any} initial model
+   * @param {Function} dispatch function
    */
-  constructor(saga, model) {
+  constructor(saga, model, dispatch) {
     this.updateModel(model);
     this.subject = new Subject();
     this.saga$ = saga(this.subject);
 
-    this.subscription = null;
+    this.subscription = this.saga$
+      .filter(isAction)
+      .subscribe(dispatch);
   }
 
   /**
@@ -29,23 +32,6 @@ export default class RxjsSaga {
    */
   updateModel(model) {
     this.model = model;
-  }
-
-  /**
-   * Subscribes to all the actions
-   * newly created by Saga implementation. It's
-   * the output of the action pipe.
-   *
-   * @param {Function} Subscriber function
-   * @return {Disposable} RXJS Disposable
-   */
-  subscribe(subscriber) {
-    this.subscription = this
-      .saga$
-      .filter(isAction)
-      .subscribe(subscriber);
-
-    return this.subscription;
   }
 
   /**

--- a/test/sagas/reduxSaga.test.js
+++ b/test/sagas/reduxSaga.test.js
@@ -14,9 +14,8 @@ function* pingPongSaga() {
 
 describe('ReduxSaga', () => {
   it('should allow to subscribe to output action stream', done => {
-    const saga = new ReduxSaga(pingPongSaga, 0);
     const subscribeSpy = spy();
-    saga.subscribe(subscribeSpy);
+    const saga = new ReduxSaga(pingPongSaga, 0, subscribeSpy);
     saga.dispatch({ type: 'Ping' });
 
     setTimeout(() => {
@@ -26,9 +25,8 @@ describe('ReduxSaga', () => {
   });
 
   it('should ignore those actions in which saga is not subscribed', done => {
-    const saga = new ReduxSaga(pingPongSaga, 0);
     const subscribeSpy = spy();
-    saga.subscribe(subscribeSpy);
+    const saga = new ReduxSaga(pingPongSaga, 0, subscribeSpy);
     saga.dispatch({ type: 'UnknownAction' });
 
     setTimeout(() => {
@@ -44,8 +42,7 @@ describe('ReduxSaga', () => {
       modelResult = yield select(model => model);
     }
 
-    const saga = new ReduxSaga(testingSaga, 42);
-    saga.subscribe(() => {});
+    const saga = new ReduxSaga(testingSaga, 42, () => {});
     saga.dispatch({ type: 'FooBar' });
 
     setTimeout(() => {
@@ -62,8 +59,7 @@ describe('ReduxSaga', () => {
       modelResult = yield select(model => model);
     }
 
-    const saga = new ReduxSaga(testingSaga, 42);
-    saga.subscribe(() => {});
+    const saga = new ReduxSaga(testingSaga, 42, () => {});
     saga.updateModel(24);
     saga.dispatch({ type: 'FooBar' });
 

--- a/test/sagas/rxjsSaga.test.js
+++ b/test/sagas/rxjsSaga.test.js
@@ -9,9 +9,8 @@ const pingPongSaga = actions$ => actions$
 
 describe('RxjsSaga', () => {
   it('should allow to subscribe to output action stream', done => {
-    const saga = new RxjsSaga(pingPongSaga, 0);
     const subscribeSpy = spy();
-    saga.subscribe(subscribeSpy);
+    const saga = new RxjsSaga(pingPongSaga, 0, subscribeSpy);
     saga.dispatch({ type: 'Ping' });
 
     setTimeout(() => {
@@ -21,9 +20,8 @@ describe('RxjsSaga', () => {
   });
 
   it('should ignore those actions in which saga is not subscribed', done => {
-    const saga = new RxjsSaga(pingPongSaga, 0);
     const subscribeSpy = spy();
-    saga.subscribe(subscribeSpy);
+    const saga = new RxjsSaga(pingPongSaga, 0, subscribeSpy);
     saga.dispatch({ type: 'UnknownAction' });
 
     setTimeout(() => {
@@ -33,9 +31,8 @@ describe('RxjsSaga', () => {
   });
 
   it('should work with identity sagas', done => {
-    const saga = new RxjsSaga(actions$ => actions$, 0);
     const subscribeSpy = spy();
-    saga.subscribe(subscribeSpy);
+    const saga = new RxjsSaga(actions$ => actions$, 0, subscribeSpy);
     saga.dispatch({ type: 'UnknownAction' });
 
     setTimeout(() => {
@@ -46,8 +43,7 @@ describe('RxjsSaga', () => {
 
   it('should pass current model as well as action', done => {
     const sagaSpy = spy();
-    const saga = new RxjsSaga(actions$ => actions$.do(sagaSpy), 42);
-    saga.subscribe(() => {});
+    const saga = new RxjsSaga(actions$ => actions$.do(sagaSpy), 42, () => {});
     saga.dispatch({ type: 'FooBar' });
 
     setTimeout(() => {
@@ -61,8 +57,7 @@ describe('RxjsSaga', () => {
 
   it('should allow updating model and passing it to the sagas', done => {
     const sagaSpy = spy();
-    const saga = new RxjsSaga(actions$ => actions$.do(sagaSpy), 42);
-    saga.subscribe(() => {});
+    const saga = new RxjsSaga(actions$ => actions$.do(sagaSpy), 42, () => {});
     saga.updateModel(24);
     saga.dispatch({ type: 'FooBar' });
 

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -1,7 +1,9 @@
 import { spy } from 'sinon';
 import { assert } from 'chai';
+import { put } from 'redux-saga/effects';
 
 import Updater from '../src/Updater';
+import SagaRepository from '../src/SagaRepository';
 import * as Actions from '../src/actions';
 
 const MockSagaAbstraction = 'Mock';
@@ -142,5 +144,23 @@ describe('Updater', () => {
 
     assert.equal(reduction, 42);
     assert.isFalse(effectExecutor.called);
+  });
+
+  it('should dispatch an action when put effect is yielded in ' +
+     'initialization phase of redux-saga', () => {
+    const realSagaRepository = new SagaRepository();
+
+    const reducer = new Updater(0, function* () {
+      yield put({ type: 'Foo' });
+    })
+    .toReducer();
+
+    reducer(undefined, {
+      type: Actions.Mount,
+      effectExecutor,
+      sagaRepository: realSagaRepository
+    });
+
+    assert.equal(spiedDispatch.firstCall.args[0].type, 'Foo');
   });
 });


### PR DESCRIPTION
This is a fix for #44

The problem was that subscription to output Saga stream was made after Saga instantiation, however in `redux-saga` version - Saga may potentially dispatch (`yield put...`) action in the initialisation phase:

eg:

```javascript
function* saga() {
  yield put({ type: 'SomeAction' });
}
```

This action is dispatched right upon Saga instantiation and therefore Saga repository has not been yet subscribed to Saga output stream and therefore the action is ignored.

The fix is easy: we just need to subscribe to output action stream inside the constructor of the Saga.